### PR TITLE
Re-add ignoreCancelled into onChunkUnload event handler

### DIFF
--- a/src/main/java/net/citizensnpcs/EventListen.java
+++ b/src/main/java/net/citizensnpcs/EventListen.java
@@ -110,7 +110,7 @@ public class EventListen implements Listener {
         respawnAllFromCoord(toCoord(event.getChunk()));
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onChunkUnload(ChunkUnloadEvent event) {
         ChunkCoord coord = toCoord(event.getChunk());
         Location loc = new Location(null, 0, 0, 0);


### PR DESCRIPTION
I removed the ignoreCancelled parameter in a previous patch to fix an issue with NPC's being despawned when chunk unloads were cancelled. The problem has reappeared and requires `ignoreCancelled = true` to fix.